### PR TITLE
Added missing header files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,8 @@ outputs:
       - include/lal/LALMetaIO*.h
       - include/lal/LIGOLwXML*.h
       - include/lal/LIGOMetadata*.h
+      - include/lal/SWIGLALMetaIO*
+      - include/lal/swiglalmetaio*
       - lib/liblalmetaio*
       - lib/pkgconfig/lalmetaio*.pc
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -50,6 +50,7 @@ outputs:
     files:
       - bin/lalmetaio_version
       - etc/lalmetaio-user-env.*
+      - include/lal/LALMetaIO*.h
       - include/lal/LIGOLwXML*.h
       - include/lal/LIGOMetadata*.h
       - lib/liblalmetaio*


### PR DESCRIPTION
This PR fixes a bug in the `metaio` package that weren't providing the `LALMetaIOVCS*.h` files.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
